### PR TITLE
New test run filters

### DIFF
--- a/paths/runs.yaml
+++ b/paths/runs.yaml
@@ -22,6 +22,8 @@ get:
       schema:
         type: object
         properties:
+          search:
+            type: string
           status:
             description: |
               A list of status values separated by comma.
@@ -31,6 +33,12 @@ get:
             type: integer
           environment:
             type: integer
+          from_start_time:
+            type: integer
+            format: int64
+          to_start_time:
+            type: integer
+            format: int64
   responses:
     200:
       description: A list of all runs.


### PR DESCRIPTION
Added support for 3 new filters:

- search (allows to search runs by. title)
- from_start_time (allows to find runs created after a given timestamp)
- to_start_time (allows to find runs created before a given timestamp)