### PR TITLE
EXEC-82 Single result endpoint

### DIFF
--- a/testops-api/README.md
+++ b/testops-api/README.md
@@ -1,0 +1,60 @@
+# Qase TestOps API specification
+
+This project contains the necessary scripts to generate Software Development Kits (SDKs) for the Qase.io TestOps API 
+using OpenAPI specifications.
+
+## Prerequisites
+
+- Docker
+- Node.js and npm
+- Go (including `goimports` for Go code formatting)
+- Ensure Docker daemon is running.
+
+## Usage
+
+The Taskfile includes several functions to validate and generate SDKs for different programming languages: 
+Go, PHP, Python, and TypeScript. Each function is tailored for the specific language requirements.
+
+### Validate the OpenAPI Specification
+
+To validate the OpenAPI specification:
+
+```bash
+./Taskfile.sh validate
+```
+
+This command uses npm to run the validation process on the OpenAPI spec file.
+
+## Generate SDKs
+
+To generate programming-language-specific SDK:
+
+```bash
+./Taskfile.sh go|php|typescript|python
+```
+
+This command cleans the existing Go/PHP/Typescript/Python SDK directory, generates a new Go SDK based on the OpenAPI spec, 
+and (for Go!) formats the code using goimports.
+
+### Install or update goimports for Go SDK generation
+
+```bash
+go install golang.org/x/tools/cmd/goimports@latest
+```
+
+## Custom OpenAPI Generator
+The `openapi` function in the Taskfile uses Docker to run the `openapitools/openapi-generator-cli` tool, 
+which is a versatile tool to generate client libraries, server stubs, and API documentation from 
+OpenAPI Specification definitions.
+
+## Notes
+
+The Taskfile is a bash script; ensure it has executable permissions (chmod +x taskfile.sh).
+Adjust the paths and configurations in the script according to your project structure and requirements.
+The OpenAPI specification file is assumed to be in the ./src.yaml path relative to the Taskfile.
+SDKs are generated into the sdk directory under language-specific subdirectories.
+
+## Contributing
+
+Contributions to improve the Taskfile or the SDK generation process are welcome. 
+Please ensure to follow the project's contribution guidelines.

--- a/testops-api/Taskfile
+++ b/testops-api/Taskfile
@@ -10,11 +10,11 @@ function validate() {
 }
 
 ### codegen
-
 function go() {
-  rm -rf sdk/go/*
+  rm -rf sdk/go
+  mkdir sdk/go
   openapi generate -i /specs/src.yaml -g go -o sdk/go -c sdk/go.yml
-  goimports -ungroup -local qase -w sdk/go/
+  goimports -local qase -w sdk/go/
 }
 
 function php() {

--- a/testops-api/paths/attachment.code.yaml
+++ b/testops-api/paths/attachment.code.yaml
@@ -1,7 +1,7 @@
 post:
   operationId: upload-attachment
   tags: [ attachments ]
-  summary: Upload attachment.
+  summary: Upload attachment
   description: |
     This method allows to upload attachment to Qase.
     Max upload size:

--- a/testops-api/paths/attachment.hash.yaml
+++ b/testops-api/paths/attachment.hash.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-attachment
   tags: [ attachments ]
-  summary: Get attachment by Hash.
+  summary: Get attachment by Hash
   description: |
     This method allows to retrieve attachment by Hash.
   parameters:
@@ -27,7 +27,7 @@ get:
 delete:
   operationId: delete-attachment
   tags: [ attachments ]
-  summary: Remove attachment by Hash.
+  summary: Remove attachment by Hash
   description: |
     This method allows to remove attachment by Hash.
   parameters:

--- a/testops-api/paths/attachments.yaml
+++ b/testops-api/paths/attachments.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-attachments
   tags: [ attachments ]
-  summary: Get all attachments.
+  summary: Get all attachments
   description: |
     This method allows to retrieve attachments.
   parameters:

--- a/testops-api/paths/author.yaml
+++ b/testops-api/paths/author.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-author
   tags: [ authors ]
-  summary: Get a specific author.
+  summary: Get a specific author
   description: |
     This method allows to retrieve a specific author.
   parameters:

--- a/testops-api/paths/authors.yaml
+++ b/testops-api/paths/authors.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-authors
   tags: [ authors ]
-  summary: Get all authors.
+  summary: Get all authors
   description: |
     This method allows to retrieve all authors in selected project.
   parameters:

--- a/testops-api/paths/case.yaml
+++ b/testops-api/paths/case.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-case
   tags: [ cases ]
-  summary: Get a specific test case.
+  summary: Get a specific test case
   description: |
     This method allows to retrieve a specific test case.
   parameters:
@@ -30,7 +30,7 @@ get:
 delete:
   operationId: delete-case
   tags: [ cases ]
-  summary: Delete test case.
+  summary: Delete test case
   description: |
     This method completely deletes a test case from repository.
   parameters:
@@ -59,7 +59,7 @@ delete:
 patch:
   operationId: update-case
   tags: [ cases ]
-  summary: Update test case.
+  summary: Update test case
   description: |
     This method updates a test case.
   parameters:

--- a/testops-api/paths/case_attach_external_issue.yaml
+++ b/testops-api/paths/case_attach_external_issue.yaml
@@ -1,8 +1,7 @@
 post:
   operationId: case-attach-external-issue
   tags: [ cases ]
-  summary: Attach the external issues to the test cases.
-
+  summary: Attach the external issues to the test cases
   parameters:
     - $ref: '../parameters/Code.yaml'
   requestBody:

--- a/testops-api/paths/case_bulk.yaml
+++ b/testops-api/paths/case_bulk.yaml
@@ -1,7 +1,7 @@
 post:
   operationId: bulk
   tags: [ cases ]
-  summary: Create test cases in bulk.
+  summary: Create test cases in bulk
   description: |
     This method allows to bulk create new test cases in a project.
 

--- a/testops-api/paths/case_detach_external_issue.yaml
+++ b/testops-api/paths/case_detach_external_issue.yaml
@@ -1,8 +1,7 @@
 post:
   operationId: case-detach-external-issue
   tags: [ cases ]
-  summary: Detach the external issues from the test cases.
-
+  summary: Detach the external issues from the test cases
   parameters:
     - $ref: '../parameters/Code.yaml'
   requestBody:

--- a/testops-api/paths/cases.yaml
+++ b/testops-api/paths/cases.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-cases
   tags: [ cases ]
-  summary: Get all test cases.
+  summary: Get all test cases
   description: |
     This method allows to retrieve all test cases stored in selected project.
 
@@ -121,7 +121,7 @@ get:
 post:
   operationId: create-case
   tags: [ cases ]
-  summary: Create a new test case.
+  summary: Create a new test case
   description: |
     This method allows to create a new test case in selected project.
 

--- a/testops-api/paths/custom_field.yaml
+++ b/testops-api/paths/custom_field.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-custom-field
   tags: [ custom-fields ]
-  summary: Get Custom Field by id.
+  summary: Get Custom Field by id
   description: |
     This method allows to retrieve custom field.
   parameters:
@@ -27,7 +27,7 @@ get:
 delete:
   operationId: delete-custom-field
   tags: [ custom-fields ]
-  summary: Delete Custom Field by id.
+  summary: Delete Custom Field by id
   description: |
     This method allows to delete custom field.
   parameters:
@@ -53,7 +53,7 @@ delete:
 patch:
   operationId: update-custom-field
   tags: [ custom-fields ]
-  summary: Update Custom Field by id.
+  summary: Update Custom Field by id
   description: |
     This method allows to update custom field.
   parameters:

--- a/testops-api/paths/custom_fields.yaml
+++ b/testops-api/paths/custom_fields.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-custom-fields
   tags: [ custom-fields ]
-  summary: Get all Custom Fields.
+  summary: Get all Custom Fields
   description: |
     This method allows to retrieve and filter custom fields.
 
@@ -51,7 +51,7 @@ get:
 post:
   operationId: create-custom-field
   tags: [ custom-fields ]
-  summary: Create new Custom Field.
+  summary: Create new Custom Field
   description: |
     This method allows to create custom field.
 

--- a/testops-api/paths/defect.yaml
+++ b/testops-api/paths/defect.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-defect
   tags: [ defects ]
-  summary: Get a specific defect.
+  summary: Get a specific defect
   description: |
     This method allows to retrieve a specific defect.
   parameters:
@@ -28,7 +28,7 @@ get:
 delete:
   operationId: delete-defect
   tags: [ defects ]
-  summary: Delete defect.
+  summary: Delete defect
   description: |
     This method completely deletes a defect from repository.
   parameters:
@@ -55,7 +55,7 @@ delete:
 patch:
   operationId: update-defect
   tags: [ defects ]
-  summary: Update defect.
+  summary: Update defect
   description: |
     This method updates a defect.
   parameters:

--- a/testops-api/paths/defect_resolve.yaml
+++ b/testops-api/paths/defect_resolve.yaml
@@ -1,7 +1,7 @@
 patch:
   operationId: resolve-defect
   tags: [ defects ]
-  summary: Resolve a specific defect.
+  summary: Resolve a specific defect
   description: |
     This method allows to resolve a specific defect.
   parameters:

--- a/testops-api/paths/defect_status.yaml
+++ b/testops-api/paths/defect_status.yaml
@@ -1,7 +1,7 @@
 patch:
   operationId: update-defect-status
   tags: [ defects ]
-  summary: Update a specific defect status.
+  summary: Update a specific defect status
   description: |
     This method allows to update a specific defect status.
   parameters:

--- a/testops-api/paths/defects.yaml
+++ b/testops-api/paths/defects.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-defects
   tags: [ defects ]
-  summary: Get all defects.
+  summary: Get all defects
   description: |
     This method allows to retrieve all defects stored in selected project.
 
@@ -40,7 +40,7 @@ get:
 post:
   operationId: create-defect
   tags: [ defects ]
-  summary: Create a new defect.
+  summary: Create a new defect
   description: |
     This method allows to create a defect in selected project.
 

--- a/testops-api/paths/environment.yaml
+++ b/testops-api/paths/environment.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-environment
   tags: [ environments ]
-  summary: Get a specific environment.
+  summary: Get a specific environment
   description: |
     This method allows to retrieve a specific environment.
   parameters:
@@ -28,7 +28,7 @@ get:
 delete:
   operationId: delete-environment
   tags: [ environments ]
-  summary: Delete environment.
+  summary: Delete environment
   description: |
     This method completely deletes an environment from repository.
   parameters:
@@ -55,7 +55,7 @@ delete:
 patch:
   operationId: update-environment
   tags: [ environments ]
-  summary: Update environment.
+  summary: Update environment
   description: |
     This method updates an environment.
   parameters:

--- a/testops-api/paths/environments.yaml
+++ b/testops-api/paths/environments.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-environments
   tags: [ environments ]
-  summary: Get all environments.
+  summary: Get all environments
   description: |
     This method allows to retrieve all environments stored in selected project.
   parameters:
@@ -29,7 +29,7 @@ get:
 post:
   operationId: create-environment
   tags: [ environments ]
-  summary: Create a new environment.
+  summary: Create a new environment
   description: |
     This method allows to create an environment in selected project.
   parameters:

--- a/testops-api/paths/milestone.yaml
+++ b/testops-api/paths/milestone.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-milestone
   tags: [ milestones ]
-  summary: Get a specific milestone.
+  summary: Get a specific milestone
   description: |
     This method allows to retrieve a specific milestone.
   parameters:
@@ -28,7 +28,7 @@ get:
 delete:
   operationId: delete-milestone
   tags: [ milestones ]
-  summary: Delete milestone.
+  summary: Delete milestone
   description: |
     This method completely deletes a milestone from repository.
   parameters:
@@ -55,7 +55,7 @@ delete:
 patch:
   operationId: update-milestone
   tags: [ milestones ]
-  summary: Update milestone.
+  summary: Update milestone
   description: |
     This method updates a milestone.
   parameters:

--- a/testops-api/paths/milestones.yaml
+++ b/testops-api/paths/milestones.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-milestones
   tags: [ milestones ]
-  summary: Get all milestones.
+  summary: Get all milestones
   description: |
     This method allows to retrieve all milestones stored in selected project.
 
@@ -36,7 +36,7 @@ get:
 post:
   operationId: create-milestone
   tags: [ milestones ]
-  summary: Create a new milestone.
+  summary: Create a new milestone
   description: |
     This method allows to create a milestone in selected project.
 

--- a/testops-api/paths/plan.yaml
+++ b/testops-api/paths/plan.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-plan
   tags: [ plans ]
-  summary: Get a specific plan.
+  summary: Get a specific plan
   description: |
     This method allows to retrieve a specific plan.
   parameters:
@@ -28,7 +28,7 @@ get:
 delete:
   operationId: delete-plan
   tags: [ plans ]
-  summary: Delete plan.
+  summary: Delete plan
   description: |
     This method completely deletes a plan from repository.
   parameters:
@@ -55,7 +55,7 @@ delete:
 patch:
   operationId: update-plan
   tags: [ plans ]
-  summary: Update plan.
+  summary: Update plan
   description: |
     This method updates a plan.
   parameters:

--- a/testops-api/paths/plans.yaml
+++ b/testops-api/paths/plans.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-plans
   tags: [ plans ]
-  summary: Get all plans.
+  summary: Get all plans
   description: |
     This method allows to retrieve all plans stored in selected project.
   parameters:
@@ -29,7 +29,7 @@ get:
 post:
   operationId: create-plan
   tags: [ plans ]
-  summary: Create a new plan.
+  summary: Create a new plan
   description: |
     This method allows to create a plan in selected project.
   parameters:

--- a/testops-api/paths/project.yaml
+++ b/testops-api/paths/project.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-project
   tags: [ projects ]
-  summary: Get Project by code.
+  summary: Get Project by code
   description: |
     This method allows to retrieve a specific project.
   parameters:
@@ -27,7 +27,7 @@ get:
 delete:
   operationId: delete-project
   tags: [ projects ]
-  summary: Delete Project by code.
+  summary: Delete Project by code
   description: |
     This method allows to delete a specific project.
   parameters:

--- a/testops-api/paths/project_access.yaml
+++ b/testops-api/paths/project_access.yaml
@@ -1,7 +1,7 @@
 post:
   operationId: grant-access-to-project
   tags: [ projects ]
-  summary: Grant access to project by code.
+  summary: Grant access to project by code
   description: |
     This method allows to grant access to a specific project.
   parameters:
@@ -35,7 +35,7 @@ post:
 delete:
   operationId: revoke-access-to-project
   tags: [ projects ]
-  summary: Revoke access to project by code.
+  summary: Revoke access to project by code
   description: |
     This method allows to revoke access to a specific project.
   parameters:

--- a/testops-api/paths/projects.yaml
+++ b/testops-api/paths/projects.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-projects
   tags: [ projects ]
-  summary: Get All Projects.
+  summary: Get All Projects
   description: |
     This method allows to retrieve all projects available
     for your account. You can limit and offset params
@@ -28,7 +28,7 @@ get:
 post:
   operationId: create-project
   tags: [ projects ]
-  summary: Create new project.
+  summary: Create new project
   description: |
     This method is used to create a new project through API.
   requestBody:

--- a/testops-api/paths/result.hash.yaml
+++ b/testops-api/paths/result.hash.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-result
   tags: [ results ]
-  summary: Get test run result by code.
+  summary: Get test run result by code
   description: |
     This method allows to retrieve a specific test run result by Hash.
   parameters:

--- a/testops-api/paths/result.id.yaml
+++ b/testops-api/paths/result.id.yaml
@@ -1,7 +1,7 @@
 post:
   operationId: create-result
   tags: [ results ]
-  summary: Create test run result.
+  summary: Create test run result
   description: |
     This method allows to create test run result by Run Id.
   parameters:

--- a/testops-api/paths/result_bulk.yaml
+++ b/testops-api/paths/result_bulk.yaml
@@ -1,7 +1,7 @@
 post:
   operationId: create-result-bulk
   tags: [ results ]
-  summary: Bulk create test run result.
+  summary: Bulk create test run result
   description: |
     This method allows to create a lot of test run result at once.
     

--- a/testops-api/paths/result_id_hash.yaml
+++ b/testops-api/paths/result_id_hash.yaml
@@ -1,7 +1,7 @@
 patch:
   operationId: update-result
   tags: [ results ]
-  summary: Update test run result.
+  summary: Update test run result
   description: |
     This method allows to update test run result.
   parameters:
@@ -37,7 +37,7 @@ patch:
 delete:
   operationId: delete-result
   tags: [ results ]
-  summary: Delete test run result.
+  summary: Delete test run result
   description: |
     This method allows to delete test run result.
   parameters:

--- a/testops-api/paths/results.yaml
+++ b/testops-api/paths/results.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-results
   tags: [ results ]
-  summary: Get all test run results.
+  summary: Get all test run results
   description: |
     This method allows to retrieve all test run
     results stored in selected project.

--- a/testops-api/paths/run.yaml
+++ b/testops-api/paths/run.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-run
   tags: [ runs ]
-  summary: Get a specific run.
+  summary: Get a specific run
   description: |
     This method allows to retrieve a specific run.
   parameters:
@@ -29,7 +29,7 @@ get:
 delete:
   operationId: delete-run
   tags: [ runs ]
-  summary: Delete run.
+  summary: Delete run
   description: |
     This method completely deletes a run from repository.
   parameters:

--- a/testops-api/paths/run_complete.yaml
+++ b/testops-api/paths/run_complete.yaml
@@ -1,7 +1,7 @@
 post:
   operationId: complete-run
   tags: [ runs ]
-  summary: Complete a specific run.
+  summary: Complete a specific run
   description: |
     This method allows to complete a specific run.
   parameters:

--- a/testops-api/paths/run_public.yaml
+++ b/testops-api/paths/run_public.yaml
@@ -1,7 +1,7 @@
 patch:
   operationId: update-run-publicity
   tags: [ runs ]
-  summary: Update publicity of a specific run.
+  summary: Update publicity of a specific run
   description: |
     This method allows to update a publicity of specific run.
   parameters:

--- a/testops-api/paths/runs.yaml
+++ b/testops-api/paths/runs.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-runs
   tags: [ runs ]
-  summary: Get all runs.
+  summary: Get all runs
   description: |
     This method allows to retrieve all runs stored in selected project.
 
@@ -61,7 +61,7 @@ get:
 post:
   operationId: create-run
   tags: [ runs ]
-  summary: Create a new run.
+  summary: Create a new run
   description: |
     This method allows to create a run in selected project.
 

--- a/testops-api/paths/search.yaml
+++ b/testops-api/paths/search.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: search
   tags: [ search ]
-  summary: Search entities by Qase Query Language (QQL).
+  summary: Search entities by Qase Query Language (QQL)
   description: |
     This method allows to retrieve data sets for various
     entities using expressions with conditions.

--- a/testops-api/paths/shared_step.yaml
+++ b/testops-api/paths/shared_step.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-shared-step
   tags: [ shared-steps ]
-  summary: Get a specific shared step.
+  summary: Get a specific shared step
   description: |
     This method allows to retrieve a specific shared step.
   parameters:
@@ -28,7 +28,7 @@ get:
 delete:
   operationId: delete-shared-step
   tags: [ shared-steps ]
-  summary: Delete shared step.
+  summary: Delete shared step
   description: |
     This method completely deletes a shared step from repository.
   parameters:
@@ -55,7 +55,7 @@ delete:
 patch:
   operationId: update-shared-step
   tags: [ shared-steps ]
-  summary: Update shared step.
+  summary: Update shared step
   description: |
     This method updates a shared step.
   parameters:

--- a/testops-api/paths/shared_steps.yaml
+++ b/testops-api/paths/shared_steps.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-shared-steps
   tags: [ shared-steps ]
-  summary: Get all shared steps.
+  summary: Get all shared steps
   description: |
     This method allows to retrieve all shared steps stored in selected project.
 
@@ -36,7 +36,7 @@ get:
 post:
   operationId: create-shared-step
   tags: [ shared-steps ]
-  summary: Create a new shared step.
+  summary: Create a new shared step
   description: |
     This method allows to create a shared step in selected project.
 

--- a/testops-api/paths/suite.yaml
+++ b/testops-api/paths/suite.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-suite
   tags: [ suites ]
-  summary: Get a specific test suite.
+  summary: Get a specific test suite
   description: |
     This method allows to retrieve a specific test suite.
   parameters:
@@ -28,7 +28,7 @@ get:
 delete:
   operationId: delete-suite
   tags: [ suites ]
-  summary: Delete test suite.
+  summary: Delete test suite
   description: |
     This method completely deletes a test suite with test cases from repository.
   parameters:
@@ -60,7 +60,7 @@ delete:
 patch:
   operationId: update-suite
   tags: [ suites ]
-  summary: Update test suite.
+  summary: Update test suite
   description: |
     This method is used to update a test suite through API.
   parameters:

--- a/testops-api/paths/suites.yaml
+++ b/testops-api/paths/suites.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-suites
   tags: [ suites ]
-  summary: Get all test suites.
+  summary: Get all test suites
   description: |
     This method allows to retrieve all test suites stored in selected project.
 
@@ -36,7 +36,7 @@ get:
 post:
   operationId: create-suite
   tags: [ suites ]
-  summary: Create a new test suite.
+  summary: Create a new test suite
   description: |
     This method is used to create a new test suite through API.
 

--- a/testops-api/paths/system_fields.yaml
+++ b/testops-api/paths/system_fields.yaml
@@ -1,7 +1,7 @@
 get:
   operationId: get-system-fields
   tags: [ system-fields ]
-  summary: Get all System Fields.
+  summary: Get all System Fields
   description: |
     This method allows to retrieve all system fields.
 

--- a/testops-api/paths/v2/result.yaml
+++ b/testops-api/paths/v2/result.yaml
@@ -1,0 +1,46 @@
+post:
+  summary: (Beta) Create test run result
+  description: |
+    This method allows to create single test run result.
+    
+    If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage.
+  operationId: create-result-v2
+  tags:
+    - result
+  parameters:
+    - name: project_code
+      in: path
+      required: true
+      schema:
+        type: string
+    - name: run_id
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int64
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../schemas/v2/ResultCreate.yaml'
+  responses:
+    "202":
+      description: OK
+    "400":
+      description: Bad Request
+    "401":
+      description: Unauthorized
+    "403":
+      description: Forbidden
+    "404":
+      description: Not Found
+    "422":
+      description: Unprocessable Entity
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '../../schemas/responses/BaseError.yaml'
+              - $ref: '../../schemas/responses/BaseErrorField.yaml'

--- a/testops-api/paths/v2/results_bulk.yaml
+++ b/testops-api/paths/v2/results_bulk.yaml
@@ -1,7 +1,7 @@
 post:
-  summary: (Beta) Bulk create test run result.
+  summary: (Beta) Bulk create test run result
   description: |
-    This method allows to create a lot of test run result at once.
+    This method allows to create several test run results at once.
     
     If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage.
   operationId: create-results-v2

--- a/testops-api/sdk/go.yml
+++ b/testops-api/sdk/go.yml
@@ -1,1 +1,3 @@
 # https://openapi-generator.tech/docs/generators/go/
+
+generateInterfaces: false

--- a/testops-api/src.yaml
+++ b/testops-api/src.yaml
@@ -33,94 +33,99 @@ tags:
   - name: suites
 
 servers:
-  - url: https://api.qase.io/v1
+  - url: https://api.qase.io
     description: The production API server.
 
 paths:
-  /attachment:
+  /v1/attachment:
     $ref: './paths/attachments.yaml'
-  /attachment/{code}:
+  /v1/attachment/{code}:
     $ref: './paths/attachment.code.yaml'
-  /attachment/{hash}:
+  /v1/attachment/{hash}:
     $ref: './paths/attachment.hash.yaml'
-  /author:
+  /v1/author:
     $ref: './paths/authors.yaml'
-  /author/{id}:
+  /v1/author/{id}:
     $ref: './paths/author.yaml'
-  /case/{code}:
+  /v1/case/{code}:
     $ref: './paths/cases.yaml'
-  /case/{code}/{id}:
+  /v1/case/{code}/{id}:
     $ref: './paths/case.yaml'
-  /case/{code}/bulk:
+  /v1/case/{code}/bulk:
     $ref: './paths/case_bulk.yaml'
-  /case/{code}/external-issue/attach:
+  /v1/case/{code}/external-issue/attach:
     $ref: './paths/case_attach_external_issue.yaml'
-  /case/{code}/external-issue/detach:
+  /v1/case/{code}/external-issue/detach:
     $ref: './paths/case_detach_external_issue.yaml'
-  /custom_field:
+  /v1/custom_field:
     $ref: './paths/custom_fields.yaml'
-  /custom_field/{id}:
+  /v1/custom_field/{id}:
     $ref: './paths/custom_field.yaml'
-  /system_field:
+  /v1/system_field:
     $ref: './paths/system_fields.yaml'
-  /defect/{code}:
+  /v1/defect/{code}:
     $ref: './paths/defects.yaml'
-  /defect/{code}/{id}:
+  /v1/defect/{code}/{id}:
     $ref: './paths/defect.yaml'
-  /defect/{code}/resolve/{id}:
+  /v1/defect/{code}/resolve/{id}:
     $ref: './paths/defect_resolve.yaml'
-  /defect/{code}/status/{id}:
+  /v1/defect/{code}/status/{id}:
     $ref: './paths/defect_status.yaml'
-  /environment/{code}:
+  /v1/environment/{code}:
     $ref: './paths/environments.yaml'
-  /environment/{code}/{id}:
+  /v1/environment/{code}/{id}:
     $ref: './paths/environment.yaml'
-  /milestone/{code}:
+  /v1/milestone/{code}:
     $ref: './paths/milestones.yaml'
-  /milestone/{code}/{id}:
+  /v1/milestone/{code}/{id}:
     $ref: './paths/milestone.yaml'
-  /plan/{code}:
+  /v1/plan/{code}:
     $ref: './paths/plans.yaml'
-  /plan/{code}/{id}:
+  /v1/plan/{code}/{id}:
     $ref: './paths/plan.yaml'
-  /project:
+  /v1/project:
     $ref: './paths/projects.yaml'
-  /project/{code}:
+  /v1/project/{code}:
     $ref: './paths/project.yaml'
-  /project/{code}/access:
+  /v1/project/{code}/access:
     $ref: './paths/project_access.yaml'
-  /result/{code}:
+  /v1/result/{code}:
     $ref: './paths/results.yaml'
-  /result/{code}/{id}:
+  /v1/result/{code}/{id}:
     $ref: './paths/result.id.yaml'
-  /result/{code}/{hash}:
+  /v1/result/{code}/{hash}:
     $ref: './paths/result.hash.yaml'
-  /result/{code}/{id}/bulk:
+  /v1/result/{code}/{id}/bulk:
     $ref: './paths/result_bulk.yaml'
-  /result/{code}/{id}/{hash}:
+  /v1/result/{code}/{id}/{hash}:
     $ref: './paths/result_id_hash.yaml'
-  /run/{code}:
+  /v1/run/{code}:
     $ref: './paths/runs.yaml'
-  /run/{code}/{id}:
+  /v1/run/{code}/{id}:
     $ref: './paths/run.yaml'
-  /run/{code}/{id}/public:
+  /v1/run/{code}/{id}/public:
     $ref: './paths/run_public.yaml'
-  /run/{code}/{id}/complete:
+  /v1/run/{code}/{id}/complete:
     $ref: './paths/run_complete.yaml'
-  /search:
+  /v1/search:
     $ref: './paths/search.yaml'
-  /shared_step/{code}:
+  /v1/shared_step/{code}:
     $ref: './paths/shared_steps.yaml'
-  /shared_step/{code}/{hash}:
+  /v1/shared_step/{code}/{hash}:
     $ref: './paths/shared_step.yaml'
-  /suite/{code}:
+  /v1/suite/{code}:
     $ref: './paths/suites.yaml'
-  /suite/{code}/{id}:
+  /v1/suite/{code}/{id}:
     $ref: './paths/suite.yaml'
 
   # new results api
-  /{project_code}/run/{run_id}/results:
+  /v1/{project_code}/run/{run_id}/results:
     $ref: './paths/v2/results_bulk.yaml'
+
+  /v2/{project_code}/run/{run_id}/result:
+    servers:
+      - url: https://api.qase.io/v2
+    $ref: './paths/v2/result.yaml'
 
 components:
   schemas:


### PR DESCRIPTION
Several changes have been made:

- Added a new endpoint.
- Removed `/v1` from base URL and added it to each path since readme.com doesn't support server overriding (it is necessary for `/v2` paths). Source: https://docs.readme.com/main/docs/openapi-compatibility-chart#path-item-object
- Added a missing `testops-api/README.md` (initially generated with ChatGPT; suggestions for changes are welcome).
- Removed full stops at the end of summaries. English language conventions suggest omitting them in headings, and these are used as H1 elements after page rendering.
