### PR TITLE
feat: update get-case specification to include 'include' field

### DIFF
--- a/testops-api/v1/paths/case.yaml
+++ b/testops-api/v1/paths/case.yaml
@@ -5,6 +5,12 @@ get:
   description: |
     This method allows to retrieve a specific test case.
   parameters:
+    - in: query
+      name: include
+      description: |
+          A list of entities to include in response separated by comma. Possible values: external_issues.
+      schema:
+          type: string
     - $ref: '../parameters/Code.yaml'
     - $ref: '../parameters/Id.yaml'
   responses:


### PR DESCRIPTION
- Added support for the `include` field in the get-case API specification.
- Enabled fetching additional related data when retrieving a test case.