### PR TITLE
feat: add testops_ids parameter and update testops_id description in spec

### DIFF
--- a/testops-api/v2/schemas/ResultCreate.yaml
+++ b/testops-api/v2/schemas/ResultCreate.yaml
@@ -11,6 +11,14 @@ properties:
     type: integer
     format: int64
     nullable: true
+    description: ID of the test case. Cannot be specified together with testopd_ids.
+  testops_ids:
+    type: array
+    items:
+      type: integer
+      format: int64
+    nullable: true
+    description: IDs of the test cases. Cannot be specified together with testopd_id.
   execution:
     $ref: './ResultExecution.yaml'
   fields:


### PR DESCRIPTION
This pull request includes a change to the `testops-api/v2/schemas/ResultCreate.yaml` file to enhance the schema definition for test case IDs.

Schema definition improvements:

* [`testops-api/v2/schemas/ResultCreate.yaml`](diffhunk://#diff-c402685b7fa4162f2278539843a55f36dfbfc1f7d8a4fda70ceeb87470ccbe93R14-R21): Added a description to the `testopd_id` property and introduced a new `testops_ids` property to allow specifying multiple test case IDs. Both properties cannot be specified together.