### PR TITLE
testops-api: add Reult.author_id property

### DIFF
--- a/testops-api/v1/schemas/Result.yaml
+++ b/testops-api/v1/schemas/Result.yaml
@@ -33,6 +33,10 @@ properties:
     format: date-time
     example: "2021-12-30T19:23:59+00:00"
     nullable: true
+  author_id:
+    type: integer
+    format: int64
+    nullable: true
   attachments:
     type: array
     items:


### PR DESCRIPTION
## What
Please add an author_id (the user who executed the test case) property to the Result object

## Why
see: https://qase.canny.io/bugs/p/assign-cases-in-runs-via-api

Test run author_id (executor) is useful for:
- data analysis
- external app which want to show the summary of test execution