### PR TITLE
fix(testops-api): add Run.defects

### DIFF
--- a/testops-api/v1/schemas/Run.yaml
+++ b/testops-api/v1/schemas/Run.yaml
@@ -101,6 +101,11 @@ properties:
     items:
       type: integer
       format: int64
+  defects:
+    type: array
+    items:
+      type: integer
+      format: int64
   plan_id:
     type: integer
     format: int64


### PR DESCRIPTION
## What
add Run.defects

## Why
defect ids are returned by [Get Run API](https://developers.qase.io/reference/get-run), when the API is requested with `include=defects` parameter.