### PR TITLE
feat(testops-api): add Run.assignees

### DIFF
--- a/testops-api/v1/parameters/extend/Runs.yaml
+++ b/testops-api/v1/parameters/extend/Runs.yaml
@@ -1,6 +1,6 @@
 name: include
 in: query
 description: |
-  Include a list of related entities IDs into response. Should be separated by comma. Possible values: cases, defects
+  Include a list of related entities IDs into response. Should be separated by comma. Possible values: cases, assignees, defects. The order of assignees is same as cases.
 schema:
   type: string

--- a/testops-api/v1/schemas/Run.yaml
+++ b/testops-api/v1/schemas/Run.yaml
@@ -101,6 +101,12 @@ properties:
     items:
       type: integer
       format: int64
+  assignees:
+    type: array
+    items:
+      type: integer
+      format: int64
+      nullable: true
   plan_id:
     type: integer
     format: int64


### PR DESCRIPTION
## What
Please add Run.assignees

## Why
see: https://qase.canny.io/bugs/p/assign-cases-in-runs-via-api

Assignee ids in test run is useful for:
- data analysis
- external app which want to show the summary of test execution