### PR TITLE
feat(testops-api): support updating assignee on create result (v2)

### DIFF
--- a/testops-api/v2/schemas/ResultCreate.yaml
+++ b/testops-api/v2/schemas/ResultCreate.yaml
@@ -76,6 +76,9 @@ properties:
   defect:
     type: boolean
     description: If true and the result is failed, the defect associated with the result will be created
+  update_assignee:
+    type: boolean
+    description: If true, assignee will be updated with executor
 required:
   - title
   - execution


### PR DESCRIPTION
## What
Please add an option to update the assignee on creating the result.

## Why
When I see the TestRun page, executors are not visible in test cases table.
If assignee would be updated by executor, I can see who executed test cases with a glance.