### PR TITLE
chore: add disallowAdditionalPropertiesIfNotPresent to Java generator config

### DIFF
--- a/testops-api/v1/sdk/java.yml
+++ b/testops-api/v1/sdk/java.yml
@@ -1,3 +1,4 @@
 # https://openapi-generator.tech/docs/generators/java/
 # ? https://openapi-generator.tech/docs/generators/java-micronaut-client/
 hideGenerationTimestamp: true
+disallowAdditionalPropertiesIfNotPresent: false

--- a/testops-api/v2/sdk/java.yml
+++ b/testops-api/v2/sdk/java.yml
@@ -1,3 +1,4 @@
 # https://openapi-generator.tech/docs/generators/java/
 # ? https://openapi-generator.tech/docs/generators/java-micronaut-client/
 hideGenerationTimestamp: true
+disallowAdditionalPropertiesIfNotPresent: false


### PR DESCRIPTION
- Enabled `disallowAdditionalPropertiesIfNotPresent` in Java generator settings
- Improves strictness of generated models by disallowing undeclared fields unless explicitly present in the schema