### PR TITLE
feat: add 'in_progress' status to TestStepResult and update descriptions

### DIFF
--- a/testops-api/v1/schemas/TestStepResult.create.yaml
+++ b/testops-api/v1/schemas/TestStepResult.create.yaml
@@ -9,6 +9,7 @@ properties:
       - passed
       - failed
       - blocked
+      - in_progress
   comment:
     type: string
     nullable: true

--- a/testops-api/v1/schemas/TestStepResult.yaml
+++ b/testops-api/v1/schemas/TestStepResult.yaml
@@ -2,6 +2,7 @@ type: object
 properties:
   status:
     type: integer
+    description: '1 - passed, 2 - failed, 3 - blocked, 5 - skipped, 7 - in_progress'
   position:
     type: integer
     deprecated: true

--- a/testops-api/v2/schemas/ResultStepStatus.yaml
+++ b/testops-api/v2/schemas/ResultStepStatus.yaml
@@ -4,3 +4,4 @@ enum:
   - failed
   - blocked
   - skipped
+  - in_progress


### PR DESCRIPTION
This pull request introduces a new `in_progress` status to the TestOps API schemas, ensuring consistency across multiple versions and endpoints. The updates include changes to the status properties, descriptions, and enumerations.

### Additions to TestOps API status handling:

* [`testops-api/v1/schemas/TestStepResult.create.yaml`](diffhunk://#diff-f023c5d32485be17128f039f21cc23f55361a37a5f55055c54bc748ad6a351bdR12): Added `in_progress` to the list of possible statuses in the `properties` section.
* [`testops-api/v1/schemas/TestStepResult.yaml`](diffhunk://#diff-4cba49b8d11902cd85a229bfc41d28bd80e827a09df6b333a55957c91f7f0a70R5): Updated the `status` property to include a description that defines the mapping of integers to statuses, now including `7 - in_progress`.
* [`testops-api/v2/schemas/ResultStepStatus.yaml`](diffhunk://#diff-e7d4ea6d0735346c953798ec8d4210b91adf0114ffe0729e29d65b72abef62e3R7): Added `in_progress` to the enumeration of possible statuses.