### PR TITLE
Add cloud run configuration properties to Run schema

### DIFF
--- a/testops-api/README.md
+++ b/testops-api/README.md
@@ -44,8 +44,9 @@ go install golang.org/x/tools/cmd/goimports@latest
 ```
 
 ## Custom OpenAPI Generator
-The `openapi` function in the Taskfile uses Docker to run the `openapitools/openapi-generator-cli` tool, 
-which is a versatile tool to generate client libraries, server stubs, and API documentation from 
+
+The `openapi` function in the Taskfile uses Docker to run the `openapitools/openapi-generator-cli` tool,
+which is a versatile tool to generate client libraries, server stubs, and API documentation from
 OpenAPI Specification definitions.
 
 ## Notes

--- a/testops-api/v1/schemas/Run.create.yaml
+++ b/testops-api/v1/schemas/Run.create.yaml
@@ -52,4 +52,19 @@ properties:
     type: string
   end_time:
     type: string
+  
+  is_cloud:
+    type: boolean
+    description: Indicates if the run is created for the Test Cases produced by AIDEN
+  cloud_run_config:
+    type: object
+    description: Configuration for the cloud run, if applicable
+    properties:
+      browser:
+        type: string
+        description: The browser to be used for the cloud run
+        enum : 
+         - "chromium"
+         - "firefox"
+         - "webkit"
 required: [title]


### PR DESCRIPTION
This pull request introduces a minor documentation update and schema enhancements for the `testops-api`. The most significant changes include the addition of new properties to the `Run.create.yaml` schema and a small formatting improvement in the `README.md`.

### Schema Enhancements:
* `testops-api/v1/schemas/Run.create.yaml`: Added two new properties to the schema:
  - `is_cloud`: A boolean indicating if the run is created for Test Cases produced by AIDEN.
  - [`cloud_run_config`](diffhunk://#diff-34ff00c84bf90be5902f244aadb2fc828c7e8117e52c564c959c79bc13488d96R55-R69): An object defining configuration details for cloud runs, including a `browser` property with allowed values of `"chromium"`, `"firefox"`, and `"webkit"`.