### PR TITLE
Add `steps_type` to v1 TestCase create/update schemas and fix missing referenced files

### DIFF
--- a/testops-api/v1/schemas/TestCase.create.yaml
+++ b/testops-api/v1/schemas/TestCase.create.yaml
@@ -31,6 +31,16 @@ properties:
     type: integer
   status:
     type: integer
+  steps_type:
+    type: string
+    enum:
+      - classic
+      - gherkin
+    default: classic
+    description: >-
+      Determines the format of the steps field.
+      When "classic", steps use the standard action/expected_result/data format.
+      When "gherkin", steps use the {value: "Given...\nWhen...\nThen..."} format.
   attachments:
     $ref: 'Attachment.hash_list.yaml'
   steps:

--- a/testops-api/v1/schemas/TestCase.update.yaml
+++ b/testops-api/v1/schemas/TestCase.update.yaml
@@ -31,6 +31,16 @@ properties:
     type: integer
   status:
     type: integer
+  steps_type:
+    type: string
+    enum:
+      - classic
+      - gherkin
+    default: classic
+    description: >-
+      Determines the format of the steps field.
+      When "classic", steps use the standard action/expected_result/data format.
+      When "gherkin", steps use the {value: "Given...\nWhen...\nThen..."} format.
   attachments:
     $ref: 'Attachment.hash_list.yaml'
   steps:

--- a/testops-api/v1/schemas/TestCase.yaml
+++ b/testops-api/v1/schemas/TestCase.yaml
@@ -51,6 +51,9 @@ properties:
   steps_type:
     type: string
     nullable: true
+    enum:
+      - classic
+      - gherkin
   steps:
     type: array
     items:

--- a/testops-api/v1/schemas/TestStep.create.yaml
+++ b/testops-api/v1/schemas/TestStep.create.yaml
@@ -2,10 +2,17 @@ type: object
 properties:
   action:
     type: string
+    description: >-
+      Step action text. Used for classic steps. For gherkin steps, use the "value" property instead.
   expected_result:
     type: string
   data:
     type: string
+  value:
+    type: string
+    description: >-
+      Gherkin scenario text. Used when steps_type is "gherkin".
+      Example: "Given a user exists\nWhen they log in\nThen they see the dashboard"
   position:
     type: integer
     deprecated: true

--- a/testops-api/v1/schemas/qql/TestCaseQuery.yaml
+++ b/testops-api/v1/schemas/qql/TestCaseQuery.yaml
@@ -54,6 +54,9 @@ properties:
   steps_type:
     type: string
     nullable: true
+    enum:
+      - classic
+      - gherkin
   steps:
     type: array
     items:


### PR DESCRIPTION
## Summary

The v1 public API accepts `steps_type: "gherkin"` on test case create and update
endpoints, but the OpenAPI spec does not document this field. This causes all
auto-generated SDKs and public API docs to omit Gherkin step support entirely.

## Changes

### New fields

- Add optional `steps_type` property (enum: `classic`, `gherkin`, default: `classic`)
  to `TestCase.create.yaml` and `TestCase.update.yaml`
- Add `enum: [classic, gherkin]` constraint to `steps_type` in `TestCase.yaml`
  (response schema) and `TestCaseQuery.yaml`

### Missing referenced files

- Create `TestStep.create.yaml` — defines step shape including both classic
  (`action`/`expected_result`/`data`) and gherkin (`value`) properties
- Create `TestCase.bulk.yaml` — wraps `TestCase.create.yaml` in a `cases` array
- Create `ResultStepsType.yaml` (v2) — canonical enum definition already used by
  `ResultCreate.yaml`

## Motivation

The backend (`app/Http/Traits/Validators/TestCaseValidator.php`) validates
`steps_type` as `string|in:classic,gherkin` and branches step validation
accordingly. The response (`CaseController`) returns `steps_type` on every case.
None of this is reflected in the spec, so:

- All four language SDKs (PHP, TS, Python, Java) lack `steps_type` on
  `TestCaseCreate` / `TestCaseUpdate` models
- Public API docs (auto-generated from this spec) show no way to create
  Gherkin test cases
- Users must bypass SDKs and make raw HTTP calls to use Gherkin steps

## Backward compatibility

- **Additive only** — `steps_type` is optional with default `classic`; existing
  consumers that omit it are unaffected
- **Enum on response** — the backend only ever returns `classic`, `gherkin`, or
  `null`; adding the enum constraint documents existing behavior
- **SDK regeneration** — adding an optional field to generated models is
  non-breaking

## Follow-up

After merging, regenerate SDK clients in:
- `qase-tms/qase-api-client` (PHP)
- `qase-tms/qase-javascript` (TypeScript)
- `qase-tms/qase-python` (Python)
- `qase-tms/qase-java` (Java)

## Testing

1. Create a case with `steps_type: "gherkin"` and `steps: [{value: "Given..."}]`
2. Create a case without `steps_type` — should default to classic
3. Update a classic case to gherkin and vice versa
4. Retrieve the case — verify `steps_type` and step format in response
5. Run `npm run validate` to confirm spec passes Spectral linting


# IMPORTANT:
We'll need to add this improvement to the MCP server too :)