### PR TITLE
APPS-2262 Add tags field to v2 ResultCreate schema

### DIFF
--- a/testops-api/v2/schemas/ResultCreate.yaml
+++ b/testops-api/v2/schemas/ResultCreate.yaml
@@ -47,6 +47,9 @@ properties:
         type: string
       is_flaky:
         type: string
+      tags:
+        type: string
+        description: Comma-separated list of tag titles to assign to the test case
       executed_by:
         type: string
         description: User who executed the test (member id, name or email)


### PR DESCRIPTION
## Summary
- Add `tags` as a documented string property in the `fields` object of `ResultCreate.yaml` (v2 API)
- Tags are sent as a comma-separated string (e.g. `"smoke,regression,login"`)
- When auto-create/auto-update is enabled in project settings, tags are synced to the test case

## Related
- App PR: https://github.com/qase-tms/app/pull/3023

## Test plan
- [ ] Spectral validation passes (`npm run validate`)
- [ ] SDK generation produces correct types for the new field