### PR TITLE
fix: add explode serialization for external_issues[ids][] parameter

### DIFF
--- a/testops-api/v1/paths/cases.yaml
+++ b/testops-api/v1/paths/cases.yaml
@@ -86,6 +86,8 @@ get:
     - in: query
       name: external_issues[ids][]
       description: A list of issue IDs.
+      style: form
+      explode: true
       schema:
           type: array
           items:


### PR DESCRIPTION
## Summary
- Without explicit `style`/`explode`, OpenAPI Generator serializes the `external_issues[ids][]` array parameter as CSV: `external_issues[ids][]=A,B`
- The Qase API expects repeated keys: `external_issues[ids][]=A&external_issues[ids][]=B`
- Adding `style: form` + `explode: true` produces `collectionFormat: multi` in generated SDKs, fixing the serialization

## Affected SDKs
All generated SDKs that use this spec (TypeScript, Go, PHP, etc.) — the array parameter will be serialized correctly after regeneration.

## Test plan
- [x] Regenerate TypeScript SDK and verify `cases-api.ts` no longer joins the array with `COLLECTION_FORMATS.csv`
- [x] Call `list_cases` with multiple `external_issues_ids` — verify all matching cases returned