### PR TITLE
DEVX-187 Add isManual / isToBeAutomated, deprecate automation in TestCase schemas

### DIFF
--- a/testops-api/v1/schemas/TestCase.create.yaml
+++ b/testops-api/v1/schemas/TestCase.create.yaml
@@ -29,6 +29,23 @@ properties:
     format: int64
   automation:
     type: integer
+    deprecated: true
+    description: >-
+      Deprecated, use `isManual` and `isToBeAutomated` instead.
+      Encodes the test case automation state as a single integer:
+      `0` = manual, `1` = manual planned to be automated, `2` = automated.
+      If both `automation` and `isManual`/`isToBeAutomated` are provided,
+      `isManual` and `isToBeAutomated` take precedence.
+  isManual:
+    type: integer
+    description: >-
+      `1` if the case is manual, `0` if it is automated.
+      Combined with `isToBeAutomated`, replaces the deprecated `automation` field.
+  isToBeAutomated:
+    type: integer
+    description: >-
+      `1` if a manual case is planned to be automated, `0` otherwise.
+      Only meaningful when `isManual = 1`; ignored when `isManual = 0`.
   status:
     type: integer
   steps_type:

--- a/testops-api/v1/schemas/TestCase.update.yaml
+++ b/testops-api/v1/schemas/TestCase.update.yaml
@@ -29,6 +29,23 @@ properties:
     format: int64
   automation:
     type: integer
+    deprecated: true
+    description: >-
+      Deprecated, use `isManual` and `isToBeAutomated` instead.
+      Encodes the test case automation state as a single integer:
+      `0` = manual, `1` = manual planned to be automated, `2` = automated.
+      If both `automation` and `isManual`/`isToBeAutomated` are provided,
+      `isManual` and `isToBeAutomated` take precedence.
+  isManual:
+    type: integer
+    description: >-
+      `1` if the case is manual, `0` if it is automated.
+      Combined with `isToBeAutomated`, replaces the deprecated `automation` field.
+  isToBeAutomated:
+    type: integer
+    description: >-
+      `1` if a manual case is planned to be automated, `0` otherwise.
+      Only meaningful when `isManual = 1`; ignored when `isManual = 0`.
   status:
     type: integer
   steps_type:

--- a/testops-api/v1/schemas/TestCase.yaml
+++ b/testops-api/v1/schemas/TestCase.yaml
@@ -30,6 +30,21 @@ properties:
     type: integer
   automation:
     type: integer
+    deprecated: true
+    description: >-
+      Deprecated, use `isManual` and `isToBeAutomated` instead.
+      Encodes the test case automation state as a single integer:
+      `0` = manual, `1` = manual planned to be automated, `2` = automated.
+  isManual:
+    type: integer
+    description: >-
+      `1` if the case is manual, `0` if it is automated.
+      Combined with `isToBeAutomated`, replaces the deprecated `automation` field.
+  isToBeAutomated:
+    type: integer
+    description: >-
+      `1` if a manual case is planned to be automated, `0` otherwise.
+      Only meaningful when `isManual = 1`; ignored when `isManual = 0`.
   status:
     type: integer
   milestone_id:


### PR DESCRIPTION
## Summary

Document the canonical automation contract for the public Cases API.

| `isManual` | `isToBeAutomated` | Resulting status                  |
|:----------:|:-----------------:|-----------------------------------|
| `1`        | `0`               | Manual                            |
| `1`        | `1`               | Manual (planned to be automated)  |
| `0`        | any               | Automated                         |

- Add `isManual` and `isToBeAutomated` (integer `0`/`1`) to:
  - `testops-api/v1/schemas/TestCase.yaml` (response)
  - `testops-api/v1/schemas/TestCase.create.yaml` (request)
  - `testops-api/v1/schemas/TestCase.update.yaml` (request)
- Mark `automation` as `deprecated: true` in all three schemas. Keep the
  field for backwards compatibility, document its legacy `0`/`1`/`2`
  encoding, and note that the new pair takes precedence when both are
  supplied in a request.
- `testops-api/v1/schemas/TestCase.bulk.yaml` inherits from `TestCase.create.yaml`
  via `$ref` — no edit needed; bulk endpoints pick up the new fields and
  the deprecation automatically.

## Why now

The backend already treats `isManual` + `isToBeAutomated` as the canonical
input (see `AutomationFieldsResolver` in qase-tms/app) and the public
contract here was the last piece lagging behind. Marking `automation` as
deprecated steers SDK consumers (qase-mcp-server and friends) toward the
explicit pair.

## Test plan

- [x] `npm --prefix testops-api run validate` (spectral) — passes, no errors.
- [ ] Optional: regenerate SDKs from this branch to sanity-check that the
      new fields and `deprecated: true` propagate correctly.