### PR TITLE
fix: align TestStepResult schema with actual API response

### DIFF
--- a/testops-api/v1/schemas/TestStepResult.yaml
+++ b/testops-api/v1/schemas/TestStepResult.yaml
@@ -6,12 +6,30 @@ properties:
   position:
     type: integer
     deprecated: true
+  comment:
+    type: string
+    description: 'Comment left for the step.'
+  start_time:
+    type: integer
+    format: int64
+    nullable: true
+    description: 'Unix timestamp of the step start time.'
+  end_time:
+    type: integer
+    format: int64
+    nullable: true
+    description: 'Unix timestamp of the step end time.'
+  duration_ms:
+    type: integer
+    format: int64
+    nullable: true
+    description: 'Step duration in milliseconds.'
   attachments:
     type: array
     items:
       $ref: 'Attachment.yaml'
   steps:
     type: array
-    description: 'Nested steps results will be here. The same structure is used for them for them.'
+    description: 'Nested steps results will be here. The same structure is used for them.'
     items:
-      type: object
+      $ref: 'TestStepResult.yaml'


### PR DESCRIPTION
## Summary

The `testops-api/v1/schemas/TestStepResult.yaml` schema did not match the actual response returned by the public API v1 (`ResultService::prepareStepsForSave` + `ResultController::formatResult`).

### Changes
- Added missing properties present in every step result:
  - `comment` — string, comment left for the step
  - `start_time` — int64, **nullable**, unix timestamp of the step start
  - `end_time` — int64, **nullable**, unix timestamp of the step end
  - `duration_ms` — int64, **nullable**, step duration in milliseconds
- Fixed `steps[].items` to recursively reference the same schema (`$ref: 'TestStepResult.yaml'`) instead of an empty `type: object`.
- Kept existing `status` and the deprecated `position`.

### Verification
Regenerated v1 SDK clients locally for all 6 languages (TypeScript, Python, PHP, C#, Java, Go) — all generate cleanly. The recursive `steps` self-reference is handled idiomatically per language (slice in Go, `List<TestStepResult>` in Java/C#, `model_rebuild()` for the forward-ref in Python, etc.).