### PR TITLE
fix: change isManual/isToBeAutomated type to boolean in TestCase schemas

### DIFF
--- a/testops-api/v1/schemas/TestCase.create.yaml
+++ b/testops-api/v1/schemas/TestCase.create.yaml
@@ -37,15 +37,15 @@ properties:
       If both `automation` and `isManual`/`isToBeAutomated` are provided,
       `isManual` and `isToBeAutomated` take precedence.
   isManual:
-    type: integer
+    type: boolean
     description: >-
-      `1` if the case is manual, `0` if it is automated.
+      `true` if the case is manual, `false` if it is automated.
       Combined with `isToBeAutomated`, replaces the deprecated `automation` field.
   isToBeAutomated:
-    type: integer
+    type: boolean
     description: >-
-      `1` if a manual case is planned to be automated, `0` otherwise.
-      Only meaningful when `isManual = 1`; ignored when `isManual = 0`.
+      `true` if a manual case is planned to be automated, `false` otherwise.
+      Only meaningful when `isManual` is `true`; ignored when `isManual` is `false`.
   status:
     type: integer
   steps_type:

--- a/testops-api/v1/schemas/TestCase.update.yaml
+++ b/testops-api/v1/schemas/TestCase.update.yaml
@@ -37,15 +37,15 @@ properties:
       If both `automation` and `isManual`/`isToBeAutomated` are provided,
       `isManual` and `isToBeAutomated` take precedence.
   isManual:
-    type: integer
+    type: boolean
     description: >-
-      `1` if the case is manual, `0` if it is automated.
+      `true` if the case is manual, `false` if it is automated.
       Combined with `isToBeAutomated`, replaces the deprecated `automation` field.
   isToBeAutomated:
-    type: integer
+    type: boolean
     description: >-
-      `1` if a manual case is planned to be automated, `0` otherwise.
-      Only meaningful when `isManual = 1`; ignored when `isManual = 0`.
+      `true` if a manual case is planned to be automated, `false` otherwise.
+      Only meaningful when `isManual` is `true`; ignored when `isManual` is `false`.
   status:
     type: integer
   steps_type:

--- a/testops-api/v1/schemas/TestCase.yaml
+++ b/testops-api/v1/schemas/TestCase.yaml
@@ -36,15 +36,15 @@ properties:
       Encodes the test case automation state as a single integer:
       `0` = manual, `1` = manual planned to be automated, `2` = automated.
   isManual:
-    type: integer
+    type: boolean
     description: >-
-      `1` if the case is manual, `0` if it is automated.
+      `true` if the case is manual, `false` if it is automated.
       Combined with `isToBeAutomated`, replaces the deprecated `automation` field.
   isToBeAutomated:
-    type: integer
+    type: boolean
     description: >-
-      `1` if a manual case is planned to be automated, `0` otherwise.
-      Only meaningful when `isManual = 1`; ignored when `isManual = 0`.
+      `true` if a manual case is planned to be automated, `false` otherwise.
+      Only meaningful when `isManual` is `true`; ignored when `isManual` is `false`.
   status:
     type: integer
   milestone_id:


### PR DESCRIPTION
## Summary

`isManual` and `isToBeAutomated` were declared as `type: integer` in the TestCase schemas, but the API serializes them as JSON **booleans** (`true`/`false`). This spec/API mismatch broke the generated clients.

In the Python client (`qase-api-client` 2.0.10) codegen produced `Optional[StrictInt]` fields. pydantic v2 `StrictInt` rejects `bool`, so **every** test case read raised a `ValidationError`:

```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for TestCase
isManual: Input should be a valid integer [type=int_type, input_value=True, input_type=bool]
isToBeAutomated: Input should be a valid integer [type=int_type, input_value=False, input_type=bool]
```

This affected all reads (`get-case`, `get-cases`) for any GUI-created case. Reported via Intercom (Akamai).

## Change

Change `isManual` and `isToBeAutomated` from `type: integer` to `type: boolean` in all three schemas, and update the descriptions accordingly:

- `v1/schemas/TestCase.yaml` (response)
- `v1/schemas/TestCase.create.yaml` (request)
- `v1/schemas/TestCase.update.yaml` (request)

The deprecated `automation` field is left untouched (`integer`, `0`/`1`/`2`).

## Why this is safe (verified against the backend)

- **Read**: both `get-case` and `get-cases` go through `CaseFormatter::formatForPublicApi`; both fields are always emitted as `true`/`false`, never `0`/`1`, never `null`.
- **Write**: `create-case` / `update-case` have no type validation on these fields and normalize them in a boolean context (`!($v ?? true)`), so `true`/`false` and `1`/`0` are handled identically. Backward compatible for existing clients sending `1`/`0`.

## Verification

Regenerated the Python v1 client from the patched spec — fields are now `Optional[StrictBool]`. Installed the generated package (pydantic 2.13.4) and ran the original repro plus edge cases:

- Original failing call now deserializes correctly (`isManual=True`, `isToBeAutomated=False`)
- `to_dict()` round-trip preserves aliases
- Missing/omitted fields → `None` (Optional), no error

## Note for client changelogs

With `StrictBool`, model objects now require `True`/`False` on **write** (an `int` `1`/`0` passed to the model is rejected client-side before the request). The backend still accepts both, so this only affects code that constructs the model with integer values. Worth calling out in the regenerated clients' changelogs.