### PR TITLE
fix: correct comma delimiters in test case filter value lists

### DIFF
--- a/testops-api/v1/paths/cases.yaml
+++ b/testops-api/v1/paths/cases.yaml
@@ -40,7 +40,7 @@ get:
       name: type
       description: |
         A list of type values separated by comma.
-        Possible values: other, functional smoke, regression,
+        Possible values: other, functional, smoke, regression,
         security, usability, performance, acceptance
       schema:
         type: string
@@ -48,20 +48,20 @@ get:
       name: behavior
       description: |
         A list of behavior values separated by comma.
-        Possible values: undefined, positive negative, destructive
+        Possible values: undefined, positive, negative, destructive
       schema:
         type: string
     - in: query
       name: automation
       description: |
         A list of values separated by comma.
-        Possible values: is-not-automated, automated to-be-automated
+        Possible values: is-not-automated, automated, to-be-automated
       schema:
         type: string
     - in: query
       name: status
       description: |
-        A list of values separated by comma. Possible values: actual, draft deprecated
+        A list of values separated by comma. Possible values: actual, draft, deprecated
       schema:
         type: string
     - in: query


### PR DESCRIPTION
## Problem

On the **Get all test cases** endpoint (`GET /case/{code}`), four query parameters document their allowed values as comma-separated, but four value pairs were joined by a space instead of a comma. A developer copying a documented value verbatim sends a value the API cannot match. The same source feeds the public docs and every generated SDK.

## Fix

| Param | Before | After |
|---|---|---|
| `type` | `functional smoke` | `functional, smoke` |
| `behavior` | `positive negative` | `positive, negative` |
| `automation` | `automated to-be-automated` | `automated, to-be-automated` |
| `status` | `draft deprecated` | `draft, deprecated` |

`severity` and `priority` on the same endpoint were already correct and are unchanged.

## Scope

Swept every documented value list across the v1 and v2 specs (all "Possible values" / "separated by comma" / "comma-separated" occurrences). These four were the only affected entries — no similar defects elsewhere.

Docs-only change; no schema or behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)