### PR TITLE
ci: upgrade rdme action to v9 to fix OpenAPI validation

### DIFF
--- a/.github/workflows/readme.yaml
+++ b/.github/workflows/readme.yaml
@@ -14,11 +14,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Sync Readme docs for v1
-        uses: readmeio/rdme@v8
+        uses: readmeio/rdme@v9
         with:
           rdme: openapi ./src.yaml --version=v1.0.0 --key=${{ secrets.README_KEY }} --id=6172e1f931427d3f983e34ff --workingDirectory=./testops-api/v1
 
       - name: Sync Readme docs for v2
-        uses: readmeio/rdme@v8
+        uses: readmeio/rdme@v9
         with:
           rdme: openapi ./src.yaml --version=v2.0.0 --key=${{ secrets.README_KEY }} --id=65b3b5175f1e14007198cbc8 --workingDirectory=./testops-api/v2


### PR DESCRIPTION
## Problem

The `publish` workflow has been failing on every push to `master` since 2026-06-25 ([failing runs](https://github.com/qase-tms/specs/actions)). The `rdme openapi` step aborts during validation with:

```
✖ Validating the API definition located at ./src.yaml...
Error resolving $ref pointer ".../testops-api/v1/schemas/qql/TestStepResult.yaml".
".../testops-api/v1/schemas/qql/TestStepResult.yaml" not found.
```

As a result, no spec changes have reached ReadMe since 2026-06-10.

## Root cause

`rdme@8` bundles the deprecated `@readme/json-schema-ref-parser@1.2.1`. This parser resolves recursive **relative** `$ref`s against the *referencing* file's directory instead of the target file's own directory.

Commit `e98dca7` ("fix: align TestStepResult schema with actual API response") changed the nested `steps` in `testops-api/v1/schemas/TestStepResult.yaml` from an inline `type: object` to a recursive self-reference (`$ref: 'TestStepResult.yaml'`).

- Referenced from the same directory (`schemas/Result.yaml`, `src.yaml`) the recursion resolves fine.
- Referenced across directories via `schemas/qql/ResultQuery.yaml` (`$ref: '../TestStepResult.yaml'`), the buggy parser resolves the nested self-reference against `schemas/qql/`, looks for the non-existent `schemas/qql/TestStepResult.yaml`, and fails.

## Fix

Upgrade the GitHub Action from `readmeio/rdme@v8` to `readmeio/rdme@v9`, which ships a modern ref parser that resolves the recursion correctly.

- **Drop-in change:** the `openapi` command and all flags (`--version`, `--id`, `--workingDirectory`, `--key`) are identical in v9, so the workflow invocation is unchanged.
- **No spec edits:** the recursive `TestStepResult.yaml` schema is left as-is.
- This is the migration path recommended by rdme's own v8 deprecation notice for legacy ReadMe projects.

## Verification

Reproduced the failure and confirmed the fix locally against the unchanged spec:

```
rdme@8  openapi:validate ./src.yaml  → Error resolving $ref .../qql/TestStepResult.yaml (fails)
rdme@9  openapi validate  ./src.yaml  → ./src.yaml is a valid OpenAPI API definition!
```

## Note on rdme@10

`rdme@10` (latest) is **not** a drop-in: it targets the "ReadMe Refactored" platform, renames `--version`→`--branch`, replaces `--id`→`--slug`, renames `--workingDirectory`→`--working-directory`, and requires `--confirm-overwrite` for CI. Migrating to v10 is a separate, deliberate effort that needs access to the ReadMe project settings and is out of scope here.