### PR TITLE
ci: validate OpenAPI specs on every PR, publish only on master

### DIFF
--- a/.github/workflows/readme.yaml
+++ b/.github/workflows/readme.yaml
@@ -5,20 +5,39 @@ on:
     branches:
       - master
       - main
+  pull_request:
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate OpenAPI spec for v1
+        uses: readmeio/rdme@v9
+        with:
+          rdme: openapi validate ./testops-api/v1/src.yaml
+
+      - name: Validate OpenAPI spec for v2
+        uses: readmeio/rdme@v9
+        with:
+          rdme: openapi validate ./testops-api/v2/src.yaml
+
   publish:
+    needs: validate
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Sync Readme docs for v1
-        uses: readmeio/rdme@v8
+        uses: readmeio/rdme@v9
         with:
           rdme: openapi ./src.yaml --version=v1.0.0 --key=${{ secrets.README_KEY }} --id=6172e1f931427d3f983e34ff --workingDirectory=./testops-api/v1
 
       - name: Sync Readme docs for v2
-        uses: readmeio/rdme@v8
+        uses: readmeio/rdme@v9
         with:
           rdme: openapi ./src.yaml --version=v2.0.0 --key=${{ secrets.README_KEY }} --id=65b3b5175f1e14007198cbc8 --workingDirectory=./testops-api/v2

--- a/.github/workflows/readme.yaml
+++ b/.github/workflows/readme.yaml
@@ -17,12 +17,12 @@ jobs:
       - name: Validate OpenAPI spec for v1
         uses: readmeio/rdme@v9
         with:
-          rdme: openapi validate ./testops-api/v1/src.yaml
+          rdme: openapi validate ./src.yaml --workingDirectory=./testops-api/v1
 
       - name: Validate OpenAPI spec for v2
         uses: readmeio/rdme@v9
         with:
-          rdme: openapi validate ./testops-api/v2/src.yaml
+          rdme: openapi validate ./src.yaml --workingDirectory=./testops-api/v2
 
   publish:
     needs: validate


### PR DESCRIPTION
## What

Split the `publish` workflow into two jobs:

- **`validate`** — runs `rdme openapi validate` for the v1 and v2 specs on **every pull request and push**. It fails on any validation error, which blocks the PR from being merged.
- **`publish`** — now `needs: validate` and is guarded by `if: github.event_name == 'push'`, so ReadMe docs are synced **only after** changes land on `master`/`main` and only when validation passed.

Also bumps the `readmeio/rdme` action from **v8 → v9**, which ships the standalone `openapi validate` command used by the new job.

## Why

Previously the workflow only ran on push to `master`/`main` and had no validation step — a broken spec could reach the sync stage. Now spec issues are caught on the PR before merge, and publishing is decoupled from PR runs.

## Behavior

| Event | Jobs run |
|-------|----------|
| Pull request | `validate` only (blocks PR on failure) |
| Push to `master`/`main` | `validate` → `publish` |
