### PR TITLE
feat: add error_context to v2 result execution and report schema

### DIFF
--- a/report/schemas/result.yaml
+++ b/report/schemas/result.yaml
@@ -26,7 +26,8 @@ properties:
         nullable: true
         description: >-
           Free-form failure context captured by the reporter. For Playwright this is the content
-          of error-context.md. Truncated at 262144 characters.
+          of error-context.md, which may include rendered page content. Reporters may truncate
+          long values; Qase truncates at 262144 characters on upload.
       thread:
         type: string
         nullable: true

--- a/report/schemas/result.yaml
+++ b/report/schemas/result.yaml
@@ -21,6 +21,12 @@ properties:
       stacktrace:
         type: string
         nullable: true
+      error_context:
+        type: string
+        nullable: true
+        description: >-
+          Free-form failure context captured by the reporter. For Playwright this is the content
+          of error-context.md. Truncated at 262144 characters.
       thread:
         type: string
         nullable: true

--- a/testops-api/v2/paths/results_bulk.yaml
+++ b/testops-api/v2/paths/results_bulk.yaml
@@ -45,5 +45,10 @@ post:
       description: Forbidden
     "404":
       description: Not Found
+    "413":
+      description: |
+        Payload Too Large. Returned when the request contains more than 2000 results, or when the
+        combined length of `execution.error_context` across the batch exceeds 4194304 characters.
+        In both cases the whole batch is rejected — no results are created.
     "422":
       description: Unprocessable Entity

--- a/testops-api/v2/schemas/ResultExecution.yaml
+++ b/testops-api/v2/schemas/ResultExecution.yaml
@@ -26,8 +26,10 @@ properties:
     nullable: true
     description: >-
       Free-form failure context captured by the reporter. For Playwright this is the content of
-      error-context.md (test info, error details, page snapshot). Stored verbatim so it can be
-      copied as raw text. Truncated at 262144 characters.
+      error-context.md (test info, error details, page snapshot), so it may include rendered page
+      content. Stored verbatim so it can be copied as raw text. Values longer than 262144
+      characters are silently truncated by Qase and the request still succeeds. Write-only — not
+      returned by the result read endpoints.
   thread:
     type: string
     nullable: true

--- a/testops-api/v2/schemas/ResultExecution.yaml
+++ b/testops-api/v2/schemas/ResultExecution.yaml
@@ -21,6 +21,13 @@ properties:
   stacktrace:
     type: string
     nullable: true
+  error_context:
+    type: string
+    nullable: true
+    description: >-
+      Free-form failure context captured by the reporter. For Playwright this is the content of
+      error-context.md (test info, error details, page snapshot). Stored verbatim so it can be
+      copied as raw text. Truncated at 262144 characters.
   thread:
     type: string
     nullable: true


### PR DESCRIPTION
## Why

Playwright ≥ 1.51 writes an `error-context.md` for each failed test (error details, ARIA page snapshot, source frame) — meant to be pasted into an AI agent or bug report. Today reporters can only send it as an opaque file attachment, so reading it means downloading the file from storage. No `error_context` concept existed in the specs.

## What

Adds a nullable, write-only `error_context` string next to `stacktrace`:

- `testops-api/v2/schemas/ResultExecution.yaml` — public API v2 (single + bulk)
- `report/schemas/result.yaml` — report file format, keeps `reporters-validator` in sync

Values over 262144 chars are truncated server-side (request still succeeds). Also documents the bulk endpoint's `413`, which was previously undocumented.

## Notes

- Purely additive and optional; the report schema has no `additionalProperties: false`, so existing reports keep validating.
- `npm run validate` (spectral) passes.
- Merging publishes docs to ReadMe.io immediately — best merged once `qase-tms/app#3640` is queued to deploy, otherwise the API silently drops the field.

## Rollout (AICP-31)

1. **this PR** (specs)
2. `qase-tms/app#3640` — storage, validation, internal endpoint, Copy button
3. `qase-tms/qase-javascript#993` — regenerated v2 client, commons model, Playwright reporter

App must reach production before a reporter release: its own e2e suite reports to production Qase.
