### PR TITLE
docs: document the shared field on test case step objects

### DIFF
--- a/testops-api/v1/schemas/TestStep.create.yaml
+++ b/testops-api/v1/schemas/TestStep.create.yaml
@@ -4,6 +4,10 @@ properties:
     type: string
     description: >-
       Step action text. Used for classic steps. For gherkin steps, use the "value" property instead.
+  shared:
+    type: string
+    description: >-
+      Hash of an existing shared step to insert at this position.
   expected_result:
     type: string
   data:


### PR DESCRIPTION
Added the `shared` property to the test case step schema (`v1/schemas/TestStep.create.yaml`). It holds the hash of an existing shared step, which the API already accepts on `POST /v1/case/{code}`, `PATCH /v1/case/{code}/{id}` and `POST /v1/case/{code}/bulk`, but which was missing from the spec — so generated SDKs had no way to attach a shared step to a case.

Refs qase-tms/qase-mcp-server#66.